### PR TITLE
fix: prevent double cbk call in Boltz WS health check

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM node:20.11.1-alpine AS base
 # ---------------
 FROM base AS setup
 
-RUN corepack enable && corepack prepare pnpm@latest --activate
+RUN corepack enable && corepack prepare pnpm@10.13.1 --activate
 
 ENV PNPM_HOME=/usr/local/bin
 ENV DISABLE_OPENCOLLECTIVE=true
@@ -43,7 +43,7 @@ RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm prune --prod --ignore-scr
 # ---------------
 FROM base
 
-RUN npm i -g pnpm
+RUN npm i -g pnpm@10.13.1
 
 ARG NODE_ENV=production
 ENV NODE_ENV=${NODE_ENV}

--- a/src/libs/boltz/boltzWs.service.ts
+++ b/src/libs/boltz/boltzWs.service.ts
@@ -76,11 +76,14 @@ export class BoltzWsService implements OnApplicationBootstrap {
 
   startHealthCheck(cbk: () => void) {
     this.healthCheckIntervalId = setInterval(() => {
+      if (this.pingTimeoutId) return;
+
       this.logger.silly(`Send ping to Boltz`);
 
       this.webSocket.ping();
 
       this.pingTimeoutId = setTimeout(() => {
+        this.pingTimeoutId = null;
         this.logger.error(`Health check timed out.`);
         this.webSocket.terminate();
         cbk();
@@ -92,6 +95,14 @@ export class BoltzWsService implements OnApplicationBootstrap {
     if (!this.pingTimeoutId) return;
     clearTimeout(this.pingTimeoutId);
     this.pingTimeoutId = null;
+  }
+
+  private stopHealthCheck() {
+    if (this.healthCheckIntervalId) {
+      clearInterval(this.healthCheckIntervalId);
+      this.healthCheckIntervalId = null;
+    }
+    this.resetHealthCheckTimeout();
   }
 
   async startSubscription() {
@@ -110,13 +121,16 @@ export class BoltzWsService implements OnApplicationBootstrap {
               ({ getPendingSwaps }, cbk) => {
                 this.logger.debug(`Setting up Boltz WS`);
 
-                this.startHealthCheck(() => {
-                  if (this.healthCheckIntervalId) {
-                    clearInterval(this.healthCheckIntervalId);
-                    this.healthCheckIntervalId = null;
-                  }
+                let cbkCalled = false;
+                const finish = (err?: Error) => {
+                  if (cbkCalled) return;
+                  cbkCalled = true;
+                  this.stopHealthCheck();
+                  cbk(err);
+                };
 
-                  cbk(Error(HEALTH_CHECK_FAILED_ERR));
+                this.startHealthCheck(() => {
+                  finish(Error(HEALTH_CHECK_FAILED_ERR));
                 });
 
                 const webSocketUrl = `${this.apiUrl.replace('https://', 'wss://')}ws`;
@@ -280,7 +294,7 @@ export class BoltzWsService implements OnApplicationBootstrap {
                   this.logger.warn('Error in Boltz websocket', { error });
 
                   this.webSocket.terminate();
-                  cbk(Error('Connection error'));
+                  finish(Error('Connection error'));
                 });
               },
             ],


### PR DESCRIPTION
fixes the `Callback was already called` crash in the boltz websocket service. the health check was creating overlapping ping timeouts and the ws error handler could fire after the health check already failed, both ending up calling the same async cbk twice. now the cbk is guarded so it only runs once and both timers get cleared on shutdown.