### PR TITLE
fix: enable discount CT and raise Liquid relay fee rate

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "handlebars": "^4.7.8",
     "ioredis": "^5.4.1",
     "js-yaml": "^4.1.0",
-    "liquidjs-lib": "^6.0.2-liquid.35",
+    "liquidjs-lib": "6.0.2-liquid.38",
     "lodash": "^4.17.21",
     "lwk_wasm": "file:lwk-wasm-0.8.4.tgz",
     "mailgun.js": "^10.4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -76,7 +76,7 @@ importers:
         version: 1.4.1
       boltz-core:
         specifier: ^2.1.3
-        version: 2.2.1(liquidjs-lib@6.0.2-liquid.36)
+        version: 2.2.1(liquidjs-lib@6.0.2-liquid.38)
       cache-manager:
         specifier: ^5.7.6
         version: 5.7.6
@@ -120,8 +120,8 @@ importers:
         specifier: ^4.1.0
         version: 4.1.0
       liquidjs-lib:
-        specifier: ^6.0.2-liquid.35
-        version: 6.0.2-liquid.36
+        specifier: 6.0.2-liquid.38
+        version: 6.0.2-liquid.38
       lodash:
         specifier: ^4.17.21
         version: 4.17.21
@@ -3824,8 +3824,8 @@ packages:
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
-  liquidjs-lib@6.0.2-liquid.36:
-    resolution: {integrity: sha512-JvQ0FmfX2UYOJy2/pJgXmnhwDoxqksR3pk9euwmNNNByXq3t/wOEKEFkL7z7KFHCTa0gmuSqC5f2T2aN9Dhnkg==}
+  liquidjs-lib@6.0.2-liquid.38:
+    resolution: {integrity: sha512-8q4u5aW1BgqxoD78Fqqeqtl9ZgWHIdLfJe634gFyLBp9xRepGDF0p2ScsqZxJfvIrwnfgCPUUicUceeZt5uUdg==}
     engines: {node: '>=8.0.0'}
 
   loader-runner@4.3.0:
@@ -7655,7 +7655,7 @@ snapshots:
       safe-buffer: 5.2.1
       secp256k1: 4.0.4
 
-  boltz-core@2.2.1(liquidjs-lib@6.0.2-liquid.36):
+  boltz-core@2.2.1(liquidjs-lib@6.0.2-liquid.38):
     dependencies:
       '@boltz/bitcoin-ops': 2.0.0
       '@openzeppelin/contracts': 5.1.0
@@ -7666,7 +7666,7 @@ snapshots:
       bitcoinjs-lib: 6.1.7
       bn.js: 5.2.1
       ecpair: 2.1.0
-      liquidjs-lib: 6.0.2-liquid.36
+      liquidjs-lib: 6.0.2-liquid.38
       varuint-bitcoin: 2.0.0
 
   boolbase@1.0.0: {}
@@ -9813,7 +9813,7 @@ snapshots:
 
   lines-and-columns@1.2.4: {}
 
-  liquidjs-lib@6.0.2-liquid.36:
+  liquidjs-lib@6.0.2-liquid.38:
     dependencies:
       '@types/randombytes': 2.0.3
       bech32: 2.0.0

--- a/src/libs/boltz/handlers/liquid.handler.ts
+++ b/src/libs/boltz/handlers/liquid.handler.ts
@@ -33,7 +33,7 @@ import {
 } from './boltz.helpers';
 import { BoltzPendingTransactionInterface } from './handler.interface';
 
-const BOLTZ_SAT_VBYTE = 0.01;
+const BOLTZ_SAT_VBYTE = 0.1;
 
 @Injectable()
 export class BoltzPendingLiquidHandler
@@ -173,36 +173,40 @@ export class BoltzPendingLiquidHandler
 
     if (!cooperative) {
       this.logger.debug(`Non cooperative spend`);
-      const claimTx = targetFee(BOLTZ_SAT_VBYTE, (fee) => {
-        if (!responsePayload.blindingKey) {
-          throw new Error(`Cannot create claim tx without blinding key`);
-        }
-        return constructClaimTransaction(
-          [
-            {
-              ...swapOutput,
-              keys,
-              preimage,
-              cooperative: false,
-              type: OutputType.Taproot,
-              txHash: lockupTx.getHash(),
-              blindingPrivateKey: Buffer.from(
-                responsePayload.blindingKey,
-                'hex',
-              ),
-              swapTree: SwapTreeSerializer.deserializeSwapTree(
-                responsePayload.swapTree,
-              ),
-              internalKey: musig.getAggregatedPublicKey(),
-            },
-          ],
-          address.toOutputScript(destinationAddress, this.network),
-          fee,
-          false,
-          this.network,
-          address.fromConfidential(destinationAddress).blindingKey,
-        );
-      });
+      const claimTx = targetFee(
+        BOLTZ_SAT_VBYTE,
+        (fee) => {
+          if (!responsePayload.blindingKey) {
+            throw new Error(`Cannot create claim tx without blinding key`);
+          }
+          return constructClaimTransaction(
+            [
+              {
+                ...swapOutput,
+                keys,
+                preimage,
+                cooperative: false,
+                type: OutputType.Taproot,
+                txHash: lockupTx.getHash(),
+                blindingPrivateKey: Buffer.from(
+                  responsePayload.blindingKey,
+                  'hex',
+                ),
+                swapTree: SwapTreeSerializer.deserializeSwapTree(
+                  responsePayload.swapTree,
+                ),
+                internalKey: musig.getAggregatedPublicKey(),
+              },
+            ],
+            address.toOutputScript(destinationAddress, this.network),
+            fee,
+            false,
+            this.network,
+            address.fromConfidential(destinationAddress).blindingKey,
+          );
+        },
+        true,
+      );
 
       // Broadcast the finalized transaction
       await this.boltzRest.broadcastTx(claimTx.toHex(), 'L-BTC');
@@ -212,29 +216,36 @@ export class BoltzPendingLiquidHandler
 
     // Create a claim transaction to be signed cooperatively via a key path spend
 
-    const claimTx = targetFee(BOLTZ_SAT_VBYTE, (fee) => {
-      if (!responsePayload.blindingKey) {
-        throw new Error(`Cannot create claim tx without blinding key`);
-      }
-      return constructClaimTransaction(
-        [
-          {
-            ...swapOutput,
-            keys,
-            preimage,
-            cooperative: true,
-            type: OutputType.Taproot,
-            txHash: lockupTx.getHash(),
-            blindingPrivateKey: Buffer.from(responsePayload.blindingKey, 'hex'),
-          },
-        ],
-        address.toOutputScript(destinationAddress, this.network),
-        fee,
-        false,
-        this.network,
-        address.fromConfidential(destinationAddress).blindingKey,
-      );
-    });
+    const claimTx = targetFee(
+      BOLTZ_SAT_VBYTE,
+      (fee) => {
+        if (!responsePayload.blindingKey) {
+          throw new Error(`Cannot create claim tx without blinding key`);
+        }
+        return constructClaimTransaction(
+          [
+            {
+              ...swapOutput,
+              keys,
+              preimage,
+              cooperative: true,
+              type: OutputType.Taproot,
+              txHash: lockupTx.getHash(),
+              blindingPrivateKey: Buffer.from(
+                responsePayload.blindingKey,
+                'hex',
+              ),
+            },
+          ],
+          address.toOutputScript(destinationAddress, this.network),
+          fee,
+          false,
+          this.network,
+          address.fromConfidential(destinationAddress).blindingKey,
+        );
+      },
+      true,
+    );
 
     // Get the partial signature from Boltz
     const boltzSig = await this.boltzRest.getSigReverseSwap(
@@ -401,30 +412,37 @@ export class BoltzPendingLiquidHandler
     }
 
     // Create a claim transaction to be signed cooperatively via a key path spend
-    const refundTx = targetFee(BOLTZ_SAT_VBYTE, (fee) => {
-      if (!responsePayload.blindingKey) {
-        throw new Error(`Cannot create claim tx without blinding key`);
-      }
+    const refundTx = targetFee(
+      BOLTZ_SAT_VBYTE,
+      (fee) => {
+        if (!responsePayload.blindingKey) {
+          throw new Error(`Cannot create claim tx without blinding key`);
+        }
 
-      return constructRefundTransaction(
-        [
-          {
-            ...swapOutput,
-            txHash: lockupTx.getHash(),
-            cooperative: true,
-            type: OutputType.Taproot,
-            keys,
-            blindingPrivateKey: Buffer.from(responsePayload.blindingKey, 'hex'),
-          },
-        ],
-        address.toOutputScript(refundAddress, this.network),
-        0,
-        this.network == networks.liquid ? fee : fee * 10,
-        false,
-        this.network,
-        address.fromConfidential(refundAddress).blindingKey,
-      );
-    });
+        return constructRefundTransaction(
+          [
+            {
+              ...swapOutput,
+              txHash: lockupTx.getHash(),
+              cooperative: true,
+              type: OutputType.Taproot,
+              keys,
+              blindingPrivateKey: Buffer.from(
+                responsePayload.blindingKey,
+                'hex',
+              ),
+            },
+          ],
+          address.toOutputScript(refundAddress, this.network),
+          0,
+          this.network == networks.liquid ? fee : fee * 10,
+          false,
+          this.network,
+          address.fromConfidential(refundAddress).blindingKey,
+        );
+      },
+      true,
+    );
     // Get the partial signature from Boltz
     const boltzSig = await this.boltzRest.postSubmarineRefundInfo(
       responsePayload.id,
@@ -506,33 +524,37 @@ export class BoltzPendingLiquidHandler
     }
 
     // Create a claim transaction to be signed cooperatively via a key path spend
-    const refundTx = targetFee(BOLTZ_SAT_VBYTE, (fee) => {
-      if (!responsePayload.lockupDetails.blindingKey) {
-        throw new Error(`Cannot create refund tx without blinding key`);
-      }
+    const refundTx = targetFee(
+      BOLTZ_SAT_VBYTE,
+      (fee) => {
+        if (!responsePayload.lockupDetails.blindingKey) {
+          throw new Error(`Cannot create refund tx without blinding key`);
+        }
 
-      return constructRefundTransaction(
-        [
-          {
-            ...swapOutput,
-            keys: refundKeys,
-            cooperative: true,
-            type: OutputType.Taproot,
-            txHash: lockupTx.getHash(),
-            blindingPrivateKey: Buffer.from(
-              responsePayload.lockupDetails.blindingKey,
-              'hex',
-            ),
-          },
-        ],
-        address.toOutputScript(refundAddress, this.network),
-        0,
-        this.network == networks.liquid ? fee : fee * 10,
-        true,
-        this.network,
-        address.fromConfidential(refundAddress).blindingKey,
-      );
-    });
+        return constructRefundTransaction(
+          [
+            {
+              ...swapOutput,
+              keys: refundKeys,
+              cooperative: true,
+              type: OutputType.Taproot,
+              txHash: lockupTx.getHash(),
+              blindingPrivateKey: Buffer.from(
+                responsePayload.lockupDetails.blindingKey,
+                'hex',
+              ),
+            },
+          ],
+          address.toOutputScript(refundAddress, this.network),
+          0,
+          this.network == networks.liquid ? fee : fee * 10,
+          true,
+          this.network,
+          address.fromConfidential(refundAddress).blindingKey,
+        );
+      },
+      true,
+    );
     // Get the partial signature from Boltz
     const boltzSig = await this.boltzRest.postChainRefundInfo(
       responsePayload.id,
@@ -666,38 +688,42 @@ export class BoltzPendingLiquidHandler
     }
 
     // Create a claim transaction to be signed cooperatively via a key path spend
-    const transaction = targetFee(BOLTZ_SAT_VBYTE, (fee) => {
-      if (!responsePayload.claimDetails.blindingKey) {
-        throw new Error(`Cannot create claim tx without blinding key`);
-      }
-      return constructClaimTransaction(
-        [
-          {
-            ...swapOutput,
-            preimage,
-            keys: claimKeys,
-            cooperative,
-            type: OutputType.Taproot,
-            txHash: lockupTx.getHash(),
-            blindingPrivateKey: Buffer.from(
-              responsePayload.claimDetails.blindingKey,
-              'hex',
-            ),
-            ...(!cooperative && {
-              swapTree: SwapTreeSerializer.deserializeSwapTree(
-                responsePayload.claimDetails.swapTree,
+    const transaction = targetFee(
+      BOLTZ_SAT_VBYTE,
+      (fee) => {
+        if (!responsePayload.claimDetails.blindingKey) {
+          throw new Error(`Cannot create claim tx without blinding key`);
+        }
+        return constructClaimTransaction(
+          [
+            {
+              ...swapOutput,
+              preimage,
+              keys: claimKeys,
+              cooperative,
+              type: OutputType.Taproot,
+              txHash: lockupTx.getHash(),
+              blindingPrivateKey: Buffer.from(
+                responsePayload.claimDetails.blindingKey,
+                'hex',
               ),
-              internalKey: musig.getAggregatedPublicKey(),
-            }),
-          },
-        ],
-        address.toOutputScript(destinationAddress, this.network),
-        fee,
-        false,
-        this.network,
-        address.fromConfidential(destinationAddress).blindingKey,
-      );
-    });
+              ...(!cooperative && {
+                swapTree: SwapTreeSerializer.deserializeSwapTree(
+                  responsePayload.claimDetails.swapTree,
+                ),
+                internalKey: musig.getAggregatedPublicKey(),
+              }),
+            },
+          ],
+          address.toOutputScript(destinationAddress, this.network),
+          fee,
+          false,
+          this.network,
+          address.fromConfidential(destinationAddress).blindingKey,
+        );
+      },
+      true,
+    );
 
     return { musig, transaction, swapOutput, boltzPublicKey };
   }


### PR DESCRIPTION
Enable discount CT on all Liquid claim/refund fee calculations by passing discountCT=true to targetFee, and bump BOLTZ_SAT_VBYTE from 0.01 to 0.1 sat/vB to meet Liquid's minimum relay fee.

Fixes 'min relay fee not met' broadcast rejections.