### PR TITLE
docs: deprecate project and point SECURITY.md at security@amboss.tech [AMB-2944]

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 
 **Banking for the Unbanked**
 
+> [!CAUTION]
+> ## This project is deprecated and no longer maintained.
+>
+> It receives **no updates, bug fixes, or security patches**, and no support is provided. Running it, or relying on any hosted instance, is entirely at your own risk.
+>
+> Vulnerability reports are still read (see [`SECURITY.md`](./SECURITY.md)) but **will not be fixed here**.
+
 ## Running locally for development
 
 ### NestJS instance

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Supported Versions
 
-All versions.
+None. This project is deprecated and no longer receives security updates, including fixes for reported vulnerabilities.
 
 ## Reporting a Vulnerability
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,4 +6,4 @@ All versions.
 
 ## Reporting a Vulnerability
 
-Please report all security vulnerabilities to [ap@amboss.tech](mailto:ap@amboss.tech).
+Please report all security vulnerabilities to [security@amboss.tech](mailto:security@amboss.tech).


### PR DESCRIPTION
Two changes:

- **Deprecation notice** at the top of the README — the project is no longer maintained and receives no security patches.
- **`SECURITY.md`** — contact moved from the personal `ap@amboss.tech` to `security@amboss.tech`. `Supported Versions` now says none instead of "All versions", which would otherwise promise fixes this project will never ship.

Opened from a fork; edits from maintainers are enabled.
